### PR TITLE
Added 'enable_security: true | false'

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration{
 
         $rootNode
             ->scalarNode('file')->isRequired()->cannotBeEmpty()->end()
-            ->scalarNode('enable_security')->defaultValue(false)->end()
+            ->booleanNode('enable_security')->defaultFalse()->end()
             ->scalarNode('consumer_key')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('consumer_secret')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('callback_url')->isRequired()->cannotBeEmpty()->end()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration{
 
         $rootNode
             ->scalarNode('file')->isRequired()->cannotBeEmpty()->end()
+            ->scalarNode('enable_security')->defaultValue(false)->end()
             ->scalarNode('consumer_key')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('consumer_secret')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('callback_url')->isRequired()->cannotBeEmpty()->end()

--- a/DependencyInjection/FOSTwitterExtension.php
+++ b/DependencyInjection/FOSTwitterExtension.php
@@ -12,7 +12,6 @@ class FOSTwitterExtension extends Extension
 {
     protected $resources = array(
         'twitter' => 'twitter.xml',
-        'security' => 'security.xml',
     );
 
     public function load(array $configs, ContainerBuilder $container)
@@ -20,6 +19,10 @@ class FOSTwitterExtension extends Extension
         $processor = new Processor();
         $configuration = new Configuration();
         $config = $processor->process($configuration->getConfigTree(), $configs);
+
+        if($config['enable_security']){
+            $this->resources['security'] = 'security.xml';
+        }
 
         $this->loadDefaults($container);
 

--- a/DependencyInjection/FOSTwitterExtension.php
+++ b/DependencyInjection/FOSTwitterExtension.php
@@ -20,7 +20,7 @@ class FOSTwitterExtension extends Extension
         $configuration = new Configuration();
         $config = $processor->process($configuration->getConfigTree(), $configs);
 
-        if($config['enable_security']){
+        if ($config['enable_security']) {
             $this->resources['security'] = 'security.xml';
         }
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Installation
         #app/config/config.yml
         fos_twitter:
             file: %kernel.root_dir%/../vendor/twitteroauth/twitteroauth/twitteroauth.php
+            enable_security: true #set it to false to use only the templating helper
             consumer_key: xxxxxx
             consumer_secret: xxxxxx
             callback_url: http://www.example.com/login_check

--- a/Resources/config/schema/twitter-1.0.xsd
+++ b/Resources/config/schema/twitter-1.0.xsd
@@ -9,6 +9,7 @@
         <xsd:complexType>
             <xsd:attribute name="alias" type="xsd:string" />
             <xsd:attribute name="file" type="xsd:string" />
+            <xsd:attribute name="enable_security" type="xsd:boolean" />
             <xsd:attribute name="callback_url" type="xsd:string" />
             <xsd:attribute name="anywhere_version" type="xsd:string" />
             <xsd:attribute name="consumer_key" type="xsd:string" />

--- a/Services/Twitter.php
+++ b/Services/Twitter.php
@@ -47,10 +47,8 @@ class Twitter {
     public function getAccessToken()
     {
         /* Check if the oauth_token is old */
-        if($this->session->has('oauth_token'))
-        {
-            if ($this->session->get('oauth_token') && ($this->session->get('oauth_token') !== $this->request->get('oauth_token')))
-            {
+        if ($this->session->has('oauth_token')) {
+            if ($this->session->get('oauth_token') && ($this->session->get('oauth_token') !== $this->request->get('oauth_token'))) {
                 $this->session->remove('oauth_token');
                 return null;
             }
@@ -68,8 +66,7 @@ class Twitter {
         !$this->session->has('oauth_token_secret') ?: $this->session->remove('oauth_token_secret', null);
 
         /* If HTTP response is 200 continue otherwise send to connect page to retry */
-        if (200 == $this->twitter->http_code)
-        {
+        if (200 == $this->twitter->http_code) {
             /* The user has been verified and the access tokens can be saved for future use */
             return $accessToken;
         }


### PR DESCRIPTION
The idea is to allow the use of the @anywhere templating helper without configuring security.
