### PR TITLE
added acces_token parameters

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -34,6 +34,8 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('file')->defaultValue('%kernel.root_dir%/../vendor/twitteroauth/twitteroauth/twitteroauth.php')->end()
                 ->scalarNode('consumer_key')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('consumer_secret')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('access_token')->defaultNull()->end()
+                ->scalarNode('access_token_secret')->defaultNull()->end()
                 ->scalarNode('callback_url')->defaultNull()->end()
                 ->scalarNode('anywhere_version')->defaultValue('1')->end()
                 ->scalarNode('alias')->defaultNull()->end()

--- a/DependencyInjection/FOSTwitterExtension.php
+++ b/DependencyInjection/FOSTwitterExtension.php
@@ -36,7 +36,7 @@ class FOSTwitterExtension extends Extension
             $container->setAlias($config['alias'], 'fos_twitter');
         }
 
-        foreach (array('file', 'consumer_key', 'consumer_secret', 'callback_url', 'anywhere_version') as $attribute) {
+        foreach (array('file', 'consumer_key', 'consumer_secret', 'callback_url', 'access_token', 'access_token_secret', 'anywhere_version') as $attribute) {
             if (isset($config[$attribute])) {
                 $container->setParameter('fos_twitter.'.$attribute, $config[$attribute]);
             }

--- a/Resources/config/twitter.xml
+++ b/Resources/config/twitter.xml
@@ -8,6 +8,8 @@
         <parameter key="fos_twitter.file">null</parameter>
         <parameter key="fos_twitter.consumer_key">null</parameter>
         <parameter key="fos_twitter.consumer_secret">null</parameter>
+        <parameter key="fos_twitter.access_token">null</parameter>
+        <parameter key="fos_twitter.access_token_secret">null</parameter>
         <parameter key="fos_twitter.callback_url">null</parameter>
         <parameter key="fos_twitter.anywhere_version">1</parameter>
         
@@ -29,6 +31,8 @@
             <file>%fos_twitter.file%</file>
             <argument key="consumer_key">%fos_twitter.consumer_key%</argument>
             <argument key="consumer_secret">%fos_twitter.consumer_secret%</argument>
+            <argument key="oauth_token">%fos_twitter.access_token%</argument>
+            <argument key="oauth_token_secret">%fos_twitter.access_token_secret%</argument>
         </service>
 
         <!-- @Anywhere Templating Helper -->


### PR DESCRIPTION
added needed options to have access_token & access_token_secret keys in the configuration file.
That way TwitterOAuth is created with access keys and no call to setOAuthToken(access_token,access_token_secret) method is needed in the simplest use case of the rest api.

See http://blog.azancadas.com/2011/09/fostwitterbundle-simple-way-to-tweet/ for a use case.
