### PR TITLE
composer.json security-bundle version fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "symfony/security-bundle": "2.0.*",
+        "symfony/security-bundle": ">=2.0,<2.2-dev",
         "kertz/twitteroauth": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "symfony/security-bundle": ">=2.0,<2.2-dev",
+        "symfony/security-bundle": "2.1.*",
         "kertz/twitteroauth": "*"
     },
     "autoload": {


### PR DESCRIPTION
The required version for security-bundle is 2.0.\* and symfony master requires 2.1.*.

Could you allow both of them? Or the bundle isn't compatible with security-bundle 2.1.*?
