### PR TITLE
Fixing argument passed to loadUserByUsername() of user provider

### DIFF
--- a/Security/Authentication/Provider/TwitterProvider.php
+++ b/Security/Authentication/Provider/TwitterProvider.php
@@ -92,7 +92,7 @@ class TwitterProvider implements AuthenticationProviderInterface
         }
 
         try {
-            $user = $this->userProvider->loadUserByUsername($accessToken['screen_name']);
+            $user = $this->userProvider->loadUserByUsername($accessToken['user_id']);
             $this->userChecker->checkPostAuth($user);
         } catch (UsernameNotFoundException $ex) {
             if (!$this->createUserIfNotExists) {


### PR DESCRIPTION
It should be user_id instead of screen_name.
