### PR TITLE
Removed wrong parameter in AuthenticationException constructor

### DIFF
--- a/Security/Authentication/Provider/TwitterProvider.php
+++ b/Security/Authentication/Provider/TwitterProvider.php
@@ -74,7 +74,7 @@ class TwitterProvider implements AuthenticationProviderInterface
         } catch (AuthenticationException $failed) {
             throw $failed;
         } catch (\Exception $failed) {
-            throw new AuthenticationException($failed->getMessage(), null, $failed->getCode(), $failed);
+            throw new AuthenticationException($failed->getMessage(), $failed->getCode(), $failed);
         }
 
         throw new AuthenticationException('The Twitter user could not be retrieved from the session.');


### PR DESCRIPTION
The AuthenticationException constructor expects 3 arguments but 4 were provided. The second one should be numeric 
